### PR TITLE
본인 인증 필요한 API 변경, 참여한 모임 목록 조회하는 API

### DIFF
--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -9,9 +9,11 @@ import {
   ParseIntPipe,
   Patch,
   HttpCode,
+  UseGuards,
 } from '@nestjs/common';
 import { EventService } from './event.service';
 import {
+  ApiBearerAuth,
   ApiCreatedResponse,
   ApiNoContentResponse,
   ApiOkResponse,
@@ -23,6 +25,9 @@ import { EventParticipantPayload } from './payload/create-eventjoin.payload';
 import { EventQuery } from './query/event.query';
 import { EventDto, EventListDto } from './dto/event.dto';
 import { PatchUpdateEventPayload } from './payload/patch-update-event.payload';
+import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
+import { CurrentUser } from 'src/auth/decorator/user.decorator';
+import { UserBaseInfo } from 'src/auth/type/user-base-info.type';
 
 @Controller('events')
 @ApiTags('Event API')
@@ -52,45 +57,64 @@ export class EventController {
     return this.eventService.getEvents(query);
   }
 
+  @Get(':me')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '내가 참여한 모임 정보를 가져옵니다' })
+  @ApiCreatedResponse({ type: EventListDto })
+  async getMyEvents(@CurrentUser() user: UserBaseInfo): Promise<EventListDto> {
+    return this.eventService.getMyEvents(user);
+  }
+
   @Post(':eventId/join')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOperation({ summary: '유저를 event에 참여시킵니다' })
   @ApiNoContentResponse()
   @HttpCode(204)
   async joinEvent(
     @Param('eventId', ParseIntPipe) eventId: number,
-    @Body() payload: EventParticipantPayload,
+    @CurrentUser() user: UserBaseInfo,
   ): Promise<void> {
-    return this.eventService.joinEvent(eventId, payload.userId);
+    return this.eventService.joinEvent(eventId, user);
   }
 
   @Post(':eventId/out')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOperation({ summary: '유저를 event에서 내보냅니다' })
   @ApiNoContentResponse()
   @HttpCode(204)
   async outEvent(
     @Param('eventId', ParseIntPipe) eventId: number,
-    @Body() payload: EventParticipantPayload,
+    @CurrentUser() user: UserBaseInfo,
   ): Promise<void> {
-    return this.eventService.outEvent(eventId, payload.userId);
+    return this.eventService.outEvent(eventId, user);
   }
 
   @Patch(':eventId')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOperation({ summary: '모임을 수정합니다' })
   @ApiOkResponse({ type: EventDto })
   async patchUpdateEvent(
     @Param('eventId', ParseIntPipe) eventId: number,
     @Body() payload: PatchUpdateEventPayload,
+    @CurrentUser() user: UserBaseInfo,
   ): Promise<EventDto> {
-    return this.eventService.patchUpdateEvent(eventId, payload);
+    return this.eventService.patchUpdateEvent(eventId, payload, user);
   }
 
   @Delete(':eventId')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @HttpCode(204)
   @ApiOperation({ summary: '모임을 삭제합니다' })
   @ApiNoContentResponse()
   async deleteEvent(
     @Param('eventId', ParseIntPipe) eventId: number,
+    @CurrentUser() user: UserBaseInfo,
   ): Promise<void> {
-    return this.eventService.deleteEvent(eventId);
+    return this.eventService.deleteEvent(eventId, user);
   }
 }

--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -35,10 +35,15 @@ export class EventController {
   constructor(private readonly eventService: EventService) {}
 
   @Post()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOperation({ summary: '새로운 모임을 추가합니다' })
   @ApiCreatedResponse({ type: EventDto })
-  async createEvent(@Body() payload: CreateEventPayload): Promise<EventDto> {
-    return this.eventService.createEvent(payload);
+  async createEvent(
+    @Body() payload: CreateEventPayload,
+    @CurrentUser() user: UserBaseInfo,
+  ): Promise<EventDto> {
+    return this.eventService.createEvent(payload, user);
   }
 
   @Get(':eventId')
@@ -61,7 +66,7 @@ export class EventController {
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: '내가 참여한 모임 정보를 가져옵니다' })
-  @ApiCreatedResponse({ type: EventListDto })
+  @ApiOkResponse({ type: EventListDto })
   async getMyEvents(@CurrentUser() user: UserBaseInfo): Promise<EventListDto> {
     return this.eventService.getMyEvents(user);
   }

--- a/src/event/event.repository.ts
+++ b/src/event/event.repository.ts
@@ -130,6 +130,34 @@ export class EventRepository {
     });
   }
 
+  async getMyEvents(userId: number): Promise<EventData[]> {
+    return this.prisma.event.findMany({
+      where: {
+        eventJoin: {
+          some: {
+            userId: userId,
+          },
+        },
+      },
+      select: {
+        id: true,
+        hostId: true,
+        title: true,
+        description: true,
+        categoryId: true,
+        eventCity: {
+          select: {
+            id: true,
+            cityId: true,
+          },
+        },
+        startTime: true,
+        endTime: true,
+        maxPeople: true,
+      },
+    });
+  }
+
   async joinEvent(userId: number, eventId: number): Promise<void> {
     await this.prisma.eventJoin.create({
       data: {

--- a/src/event/event.service.ts
+++ b/src/event/event.service.ts
@@ -33,11 +33,6 @@ export class EventService {
       maxPeople: payload.maxPeople,
     };
 
-    const HostExist = await this.eventRepository.isUserExist(payload.hostId);
-    if (!HostExist) {
-      throw new NotFoundException('해당 유저가 존재하지 않습니다.');
-    }
-
     const CategoryExist = await this.eventRepository.isCategoryExist(
       payload.categoryId,
     );
@@ -122,11 +117,6 @@ export class EventService {
   }
 
   async outEvent(eventId: number, user: UserBaseInfo): Promise<void> {
-    const validUser = await this.eventRepository.isUserExist(user.id);
-    if (!validUser) {
-      throw new NotFoundException('해당 유저가 존재하지 않습니다.');
-    }
-
     const event = await this.eventRepository.getEventById(eventId);
     if (!event) {
       throw new NotFoundException('모임이 존재하지 않습니다.');


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc

## Purpose
- 본인 인증이 필요한 API들 변경
- 유저가 참여한 모임의 목록을 조회하는 GET /me 메서드 구현


## Why
- 어떤 이유로 작업하셨나요?(Optional)


## Additional context
- 추가로 알리고 싶으신 내용이 있으신가요?


## Checklist
- Merge 나 Deploy 시 확인이 필요한 부분이 있다면 적어주세요.